### PR TITLE
nvm install over use

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Custom Actions is a serverless platform that opens the Braintree ecosystem to yo
 > We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions easily
 
 ```sh
-nvm use && npm i
+nvm install && npm install
 ```
 
 ### Testing locally


### PR DESCRIPTION
`nvm use` only uses the node version, but `nvm install` would install the version and then use it.