### PR TITLE
Removes settlementTimestamp from CaptureTransaction handler

### DIFF
--- a/src/handlers/CaptureTransaction.ts
+++ b/src/handlers/CaptureTransaction.ts
@@ -12,7 +12,6 @@ export const CaptureTransactionHandler = async (
   return {
     transactionStatusEvent: {
       id: transaction.id,
-      settlementTimestamp: new Date(),
       status: BraintreeTransactionStatus.SUBMITTED_FOR_SETTLEMENT
     }
   };


### PR DESCRIPTION
Since by returning a settlementTimstamp in the CaptureTransaction
handler triggers the braintree gateway settlement mechanism, we've
decided to remove it from this template and document this behaviour
better.

This way, the CaptureBatch handler does not get invoked, which is a
handler that is not even in this template.